### PR TITLE
Use default from address to avoid mailers going to SPAM.

### DIFF
--- a/app/mailers/expiring_free_trial_mailer.rb
+++ b/app/mailers/expiring_free_trial_mailer.rb
@@ -10,8 +10,7 @@ class ExpiringFreeTrialMailer < ApplicationMailer
     @user       = user
     @expiration = @user.trial_ends_at
     @subject    = "Your free trail to My Site Archive expires in #{time_ago_in_words(@expiration)}."
-    @from       = "stevepolito@hey.com"
 
-    mail to: @user.email, from: @from, subject: @subject
+    mail to: @user.email, subject: @subject
   end
 end

--- a/test/mailers/expiring_free_trial_mailer_test.rb
+++ b/test/mailers/expiring_free_trial_mailer_test.rb
@@ -8,7 +8,6 @@ class ExpiringFreeTrialMailerTest < ActionMailer::TestCase
     mail = ExpiringFreeTrialMailer.reminder(user: user)
     assert_match time_ago_in_words(user.trial_ends_at), mail.subject
     assert_equal [user.email], mail.to
-    assert_equal ["stevepolito@hey.com"], mail.from
   end
 
 end


### PR DESCRIPTION
Closes #99 