### PR TITLE
Update job to delete guest users who are confirmed.

### DIFF
--- a/app/jobs/purge_guest_accounts_job.rb
+++ b/app/jobs/purge_guest_accounts_job.rb
@@ -2,6 +2,6 @@ class PurgeGuestAccountsJob < ApplicationJob
   queue_as :default
 
   def perform
-    User.guest.not_confirmed.destroy_all
+    User.guest.destroy_all
   end
 end

--- a/test/jobs/purge_guest_accounts_job_test.rb
+++ b/test/jobs/purge_guest_accounts_job_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class PurgeGuestAccountsJobTest < ActiveJob::TestCase
   test "should destroy guest user and associated records" do
-    assert_difference(["Archive.count","Website.count", "Webpage.count", "Screenshot.count", "ZoneFile.count", "HtmlDocument.count", "Stat.count"], -1) do
+    assert_difference(["User.count", "Archive.count","Website.count", "Webpage.count", "Screenshot.count", "ZoneFile.count", "HtmlDocument.count", "Stat.count"], -1) do
       PurgeGuestAccountsJob.perform_now
     end
   end


### PR DESCRIPTION
They're confirmed because I set it that way to prevent mailers from going out.

Closes #142 