### PR TITLE
Prevent false negative reCAPTCHA responses.

### DIFF
--- a/app/controllers/archives_controller.rb
+++ b/app/controllers/archives_controller.rb
@@ -26,7 +26,14 @@ class ArchivesController < ApplicationController
   def create
     @archive = @guest_user.archives.build(archive_params)
     if ArchivePolicy.new(set_guest_user, @archive).new?
-      if verify_recaptcha(model: @archive) && @archive.save
+
+      validated = false
+
+      if verify_recaptcha == true
+        validated = true
+      end
+
+      if validated == true && @archive.save
         @website = @archive.create_website_for_report
         @archive.generate_report(@website, archive_params[:url])
         redirect_to @archive


### PR DESCRIPTION
I was running into an issue where `verifiy_captcha` would always return `false` on the first submission. I found [this issue](https://github.com/ambethia/recaptcha/issues/219#issuecomment-310465160) and decided to implement this verbose solution. It seems to fix it locally.

I have `local: true,  data: { turbo: "false" }` in my form, so I'm not sure what the underlying issue is.

Closes #153 